### PR TITLE
update to the latest build 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 packages
+.dart_tool/
+.pub/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,438 +2,504 @@
 # See http://pub.dartlang.org/doc/glossary.html#lockfile
 packages:
   analyzer:
+    dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.30.0+4"
   args:
+    dependency: "direct main"
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.7"
   async:
+    dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.13.3"
+    version: "2.0.2"
   barback:
+    dependency: transitive
     description:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.2+13"
   bazel_worker:
+    dependency: transitive
     description:
       name: bazel_worker
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.8"
   boolean_selector:
+    dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   browser:
+    dependency: "direct main"
     description:
       name: browser
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.0+2"
   build:
+    dependency: "direct overridden"
     description:
       path: build
-      ref: kernel
-      resolved-ref: "4003000177c79bf66be5b9d4e3f382089fa145e1"
+      ref: master
+      resolved-ref: "86fa08da81a87f2da6e21bc91e85f2dbdbbb124e"
       url: "https://github.com/dart-lang/build"
     source: git
     version: "0.11.2"
   build_barback:
+    dependency: transitive
     description:
       name: build_barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
-  build_compilers:
+    version: "0.5.0+1"
+  build_config:
+    dependency: "direct overridden"
     description:
-      path: build_compilers
-      ref: kernel
-      resolved-ref: "4003000177c79bf66be5b9d4e3f382089fa145e1"
+      path: build_config
+      ref: master
+      resolved-ref: "86fa08da81a87f2da6e21bc91e85f2dbdbbb124e"
       url: "https://github.com/dart-lang/build"
     source: git
-    version: "0.1.1-dev"
-  build_config:
-    description:
-      name: build_config
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
+    version: "0.2.1"
   build_runner:
+    dependency: "direct overridden"
     description:
       path: build_runner
-      ref: kernel
-      resolved-ref: "4003000177c79bf66be5b9d4e3f382089fa145e1"
+      ref: master
+      resolved-ref: "86fa08da81a87f2da6e21bc91e85f2dbdbbb124e"
       url: "https://github.com/dart-lang/build"
     source: git
-    version: "0.7.0-dev"
+    version: "0.7.5-dev"
   build_test:
+    dependency: "direct overridden"
     description:
       path: build_test
-      ref: kernel
-      resolved-ref: "4003000177c79bf66be5b9d4e3f382089fa145e1"
+      ref: master
+      resolved-ref: "86fa08da81a87f2da6e21bc91e85f2dbdbbb124e"
       url: "https://github.com/dart-lang/build"
     source: git
-    version: "0.9.2"
+    version: "0.9.4"
+  build_web_compilers:
+    dependency: "direct overridden"
+    description:
+      path: build_web_compilers
+      ref: master
+      resolved-ref: "86fa08da81a87f2da6e21bc91e85f2dbdbbb124e"
+      url: "https://github.com/dart-lang/build"
+    source: git
+    version: "0.2.0-dev"
   built_collection:
+    dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
   built_value:
+    dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.3.3"
   charcode:
+    dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   cli_util:
+    dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2+1"
   code_builder:
+    dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
   code_transformers:
+    dependency: transitive
     description:
       name: code_transformers
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.1+3"
   collection:
+    dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.3"
+    version: "1.14.5"
   convert:
+    dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   crypto:
+    dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2+1"
   csslib:
+    dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.1"
   dart_style:
+    dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   fixnum:
+    dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.5"
   front_end:
+    dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0-alpha.4.1"
   glob:
+    dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
   graphs:
+    dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
   html:
+    dependency: transitive
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.2"
+    version: "0.13.2+1"
   http:
+    dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+16"
   http_multi_server:
+    dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.4"
   http_parser:
+    dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
   io:
+    dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
   isolate:
+    dependency: transitive
     description:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   js:
+    dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
   json_annotation:
+    dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   kernel:
+    dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0-alpha.1.1"
   logging:
+    dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+1"
   matcher:
+    dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.1+4"
   meta:
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
-  millisecond:
-    description:
-      name: millisecond
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0"
   mime:
+    dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.5"
   multi_server_socket:
+    dependency: transitive
     description:
       name: multi_server_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   node_preamble:
+    dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
   package_config:
+    dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   package_resolver:
+    dependency: transitive
     description:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   path:
+    dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.2"
   plugin:
+    dependency: transitive
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0+2"
   pool:
+    dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.4"
   protobuf:
+    dependency: transitive
     description:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.0"
   pub_semver:
+    dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.2"
   quiver:
+    dependency: "direct main"
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.22.0"
   scratch_space:
+    dependency: transitive
     description:
       name: scratch_space
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.1+2"
   shelf:
+    dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   shelf_packages_handler:
+    dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   shelf_static:
+    dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.7"
   shelf_web_socket:
+    dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.2"
   source_map_stack_trace:
+    dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.4"
   source_maps:
+    dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.4"
   source_span:
+    dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
   stack_trace:
+    dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.1"
   stream_channel:
+    dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   stream_transform:
+    dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.9"
   string_scanner:
+    dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   term_glyph:
+    dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   test:
+    dependency: transitive
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.29"
+    version: "0.12.30"
   typed_data:
+    dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
   utf:
+    dependency: transitive
     description:
       name: utf
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0+3"
   watcher:
+    dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.7+4"
   web_socket_channel:
+    dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.6"
   yaml:
+    dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-edge.c1d83e3601e53fd0afc2864e65e4a43515050ad0"
+  dart: ">=2.0.0-dev.15.0 <=2.0.0-edge.88915b6efb7bcaf5880895c300b0e6cf5bd8a038"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,22 +12,27 @@ dependency_overrides:
   build:
     git:
       url: https://github.com/dart-lang/build
-      ref: kernel
+      ref: master
       path: build
-  build_compilers:
+  build_config:
     git:
       url: https://github.com/dart-lang/build
-      ref: kernel
-      path: build_compilers
+      ref: master
+      path: build_config
+  build_web_compilers:
+    git:
+      url: https://github.com/dart-lang/build
+      ref: master
+      path: build_web_compilers
   build_runner:
     git:
       url: https://github.com/dart-lang/build
-      ref: kernel
+      ref: master
       path: build_runner
   build_test:
     git:
       url: https://github.com/dart-lang/build
-      ref: kernel
+      ref: master
       path: build_test
 web:
   compiler:

--- a/tool/build.dart
+++ b/tool/build.dart
@@ -3,66 +3,37 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
-import 'package:build/build.dart';
-import 'package:build_compilers/build_compilers.dart';
+import 'package:build_config/build_config.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/builder.dart';
-import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:build_web_compilers/build_web_compilers.dart';
 
-Future main() async {
-  var graph = new PackageGraph.forThisPackage();
-  var buildActions = <BuildAction>[
-    new BuildAction(new TestBootstrapBuilder(), graph.root.name,
-        inputs: ['test/**_test.dart']),
-    new BuildAction(new ThrowingBuilder(), graph.root.name),
+Future main(List<String> args) async {
+  var builders = [
+    apply('ton80|test_bootstrap', [(_) => new TestBootstrapBuilder()], toRoot(),
+        defaultGenerateFor:
+            const InputSet(include: const ['test/**_test.dart']),
+        hideOutput: true),
+    apply(
+        'build_web_compilers|ddc',
+        [
+          (_) => new ModuleBuilder(),
+          (_) => new UnlinkedSummaryBuilder(),
+          (_) => new LinkedSummaryBuilder(),
+          (_) => new DevCompilerBuilder(),
+        ],
+        toAllPackages(),
+        isOptional: true,
+        hideOutput: true),
+    apply('build_web_compilers|entrypoint',
+        [(_) => new WebEntrypointBuilder(WebCompiler.DartDevc)], toRoot(),
+        defaultGenerateFor: const InputSet(include: const [
+          'web/**.dart',
+          'test/**.browser_test.dart',
+        ]),
+        hideOutput: true)
   ];
 
-  void addBuilderForAll(Builder builder, String inputExtension) {
-    for (var packageNode in graph.orderedPackages) {
-      buildActions
-          .add(new BuildAction(builder, packageNode.name, isOptional: true));
-    }
-  }
-
-  addBuilderForAll(new ModuleBuilder(), '.dart');
-  addBuilderForAll(new UnlinkedSummaryBuilder(), moduleExtension);
-  addBuilderForAll(new LinkedSummaryBuilder(), moduleExtension);
-  addBuilderForAll(new DevCompilerBuilder(), moduleExtension);
-
-  buildActions.add(new BuildAction(
-      new DevCompilerBootstrapBuilder(), graph.root.name,
-      inputs: ['web/**.dart', 'test/**.browser_test.dart']));
-
-  var serveHandler = await watch(
-    buildActions,
-    deleteFilesByDefault: true,
-    writeToCache: true,
-  );
-
-  var server =
-      await shelf_io.serve(serveHandler.handlerFor('web'), 'localhost', 8080);
-  var testServer =
-      await shelf_io.serve(serveHandler.handlerFor('test'), 'localhost', 8081);
-
-  await serveHandler.currentBuild;
-  stderr.writeln('Serving `web` at http://localhost:8080/');
-  stderr.writeln('Serving `test` at http://localhost:8081/');
-
-  await serveHandler.buildResults.drain();
-  await server.close();
-  await testServer.close();
-}
-
-class ThrowingBuilder extends Builder {
-  @override
-  final buildExtensions = {
-    '.fail': ['.fail.message']
-  };
-
-  @override
-  Future<Null> build(BuildStep buildStep) async {
-    throw await buildStep.readAsString(buildStep.inputId);
-  }
+  await run(args, builders);
 }


### PR DESCRIPTION
I also changed the script to use the `run` method to get default command line args support.

That does mean you will need to add the `serve` command explicitly, so you would do `dart tool/build.dart serve`. You can also do `build`, `watch`, and `test`.

This also gives you access to other built in commands, you can use the `help` command or no command to see what is available.